### PR TITLE
Broaden support for SAMD51 devices

### DIFF
--- a/Examples/platformio/platformio.ini
+++ b/Examples/platformio/platformio.ini
@@ -78,8 +78,20 @@ framework = arduino
 ; Platformio gets confused between ESP32 WiFi.h and nanble's WiFi.h :-(
 lib_ldf_mode = chain+
 
+[env:adafruit_grandcentral_m4]
+build_flags = -D __SAMD51__
+platform = atmelsam
+board = adafruit_grandcentral_m4
+framework = arduino
+
+[env:adafruit_metro_m4]
+build_flags = -D __SAMD51__
+platform = atmelsam
+board = adafruit_metro_m4
+framework = arduino
+
 [env:featherm4]
-build_flags = -D __FEATHER_M4__
+build_flags = -D __SAMD51__
 platform = atmelsam
 board = adafruit_feather_m4
 framework = arduino

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Make sure to use the appropriate platform define before including from `ustd`.
 | FeatherM0 | `__FEATHER_M0__`    | Adafruit feather M0 (Wifi)             |
 | RP PICO   | `__RP2040__`        | Raspberry Pi PICO RP2040               |
 | SAMD51    | `__SAMD51__`        | SAMD51 variants (Adafruit M4 boards)   |
-| FeatherM4 | `__FEATHER_M4__`    | Adafruit feather M4 (Wifi)             |
 | STM32     | `__BLUEPILL__`      | STM32F103C8T6 ARM Cortex-M3            |
 | STM32     | `__BLACKPILL__`     | STM32F411 ARM Cortex-M4                |
 | NRF52     | `__NRF52__`         | Feather NRF52832 Cortex-M4             |
@@ -69,27 +68,27 @@ platform defines are used to generate feature-lists that are used by muwerk's mo
 
 #### Family defines
 
-| Platform define  | Automatically defined family | Comment              |
-| ---------------- | ---------------------------- | -------------------- |
-| `__UNO__`        | `__ARDUINO__`                | 8-bit Atmel Arduinos |
-| `__MEGA__`       | `__ARDUINO__`                | "                    |
-| `__FEATHER_MO__` | `__ARM__`                    | ARM cortex           |
-| `__RP2040__`     | `__ARM__`, `__RP_PICO__`     | "                    |
-| `__SAMD51__`     | `__ARM__`                    | "                    |
-| `__FEATHER_M4__` | `__ARM__`                    | "                    |
-| `__BLUEPILL__`   | `__ARM__`                    | "                    |
-| `__BLACKPILL__`  | `__ARM__`                    | "                    |
-| `__NRF52__`      | `__ARM__`                    | "                    |
-| `__TEENSY40__`   | `__ARM__`                    | "                    |
-| `__NANOBLE__`    | `__ARM__`                    | "                    |
-| `__ESP__`        | `__TENSILICA__`              | Espressif Tensilica  |
-| `__ESP32__`      | `__TENSILICA__`              | "                    |
-| `__ESPDEV__`     | `__TENSILICA__`              | "                    |
-| `__ESP32_RISC__` | `__RISC_V__`                 | RISC-V ESP32-C3      |
-| `__MAIXBIT__`    | `__RISC_V__`                 | RISC-V based MCUs    |
-| `__LONGAN_NANO__`| `__RISC_V__`                 | RISC-V based MCUs    |
-| `__APPLE__`      | `__UNIXOID__`                | macOS computer       |
-| `__linux__`      | `__UNIXOID__`                | Linux computer       |
+| Platform define  | Automatically defined family | Comment                                 |
+| ---------------- | ---------------------------- | --------------------------------------- |
+| `__UNO__`        | `__ARDUINO__`                | 8-bit Atmel Arduinos                    |
+| `__MEGA__`       | `__ARDUINO__`                | "                                       |
+| `__FEATHER_MO__` | `__ARM__`                    | ARM cortex                              |
+| `__RP2040__`     | `__ARM__`, `__RP_PICO__`     | "                                       |
+| `__SAMD51__`     | `__ARM__`                    | "                                       |
+| `__FEATHER_M4__` | `__ARM__`                    | " (Deprecated in favor of `__SAMD51__`) |
+| `__BLUEPILL__`   | `__ARM__`                    | "                                       |
+| `__BLACKPILL__`  | `__ARM__`                    | "                                       |
+| `__NRF52__`      | `__ARM__`                    | "                                       |
+| `__TEENSY40__`   | `__ARM__`                    | "                                       |
+| `__NANOBLE__`    | `__ARM__`                    | "                                       |
+| `__ESP__`        | `__TENSILICA__`              | Espressif Tensilica                     |
+| `__ESP32__`      | `__TENSILICA__`              | "                                       |
+| `__ESPDEV__`     | `__TENSILICA__`              | "                                       |
+| `__ESP32_RISC__` | `__RISC_V__`                 | RISC-V ESP32-C3                         |
+| `__MAIXBIT__`    | `__RISC_V__`                 | RISC-V based MCUs                       |
+| `__LONGAN_NANO__`| `__RISC_V__`                 | RISC-V based MCUs                       |
+| `__APPLE__`      | `__UNIXOID__`                | macOS computer                          |
+| `__linux__`      | `__UNIXOID__`                | Linux computer                          |
 
 #### Features
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Make sure to use the appropriate platform define before including from `ustd`.
 | Arduino   | `__ATMEGA__`        | Should work with most arduinos         |
 | FeatherM0 | `__FEATHER_M0__`    | Adafruit feather M0 (Wifi)             |
 | RP PICO   | `__RP2040__`        | Raspberry Pi PICO RP2040               |
+| SAMD51    | `__SAMD51__`        | SAMD51 variants (Adafruit M4 boards)   |
 | FeatherM4 | `__FEATHER_M4__`    | Adafruit feather M4 (Wifi)             |
 | STM32     | `__BLUEPILL__`      | STM32F103C8T6 ARM Cortex-M3            |
 | STM32     | `__BLACKPILL__`     | STM32F411 ARM Cortex-M4                |
@@ -74,6 +75,7 @@ platform defines are used to generate feature-lists that are used by muwerk's mo
 | `__MEGA__`       | `__ARDUINO__`                | "                    |
 | `__FEATHER_MO__` | `__ARM__`                    | ARM cortex           |
 | `__RP2040__`     | `__ARM__`, `__RP_PICO__`     | "                    |
+| `__SAMD5__`      | `__ARM__`                    | "                    |
 | `__FEATHER_M4__` | `__ARM__`                    | "                    |
 | `__BLUEPILL__`   | `__ARM__`                    | "                    |
 | `__BLACKPILL__`  | `__ARM__`                    | "                    |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ platform defines are used to generate feature-lists that are used by muwerk's mo
 | `__MEGA__`       | `__ARDUINO__`                | "                    |
 | `__FEATHER_MO__` | `__ARM__`                    | ARM cortex           |
 | `__RP2040__`     | `__ARM__`, `__RP_PICO__`     | "                    |
-| `__SAMD5__`      | `__ARM__`                    | "                    |
+| `__SAMD51__`     | `__ARM__`                    | "                    |
 | `__FEATHER_M4__` | `__ARM__`                    | "                    |
 | `__BLUEPILL__`   | `__ARM__`                    | "                    |
 | `__BLACKPILL__`  | `__ARM__`                    | "                    |

--- a/ustd_platform.h
+++ b/ustd_platform.h
@@ -208,6 +208,9 @@ A Platform sets USTD_FEATURE_MEMORY to one of the above _MEM_ defines.
 //    - Adafruit Metro M4 Express
 //    - ...
 #if defined(__SAMD51__) || defined(__FEATHER_M4__)
+#if defined(__FEATHER_M4__)
+#warning "__FEATHER_M4__ has been deprecated in favor of __SAMD51__"
+#endif
 #if defined(KNOWN_PLATFORM)
 #error "Platform already defined"
 #endif

--- a/ustd_platform.h
+++ b/ustd_platform.h
@@ -202,8 +202,12 @@ A Platform sets USTD_FEATURE_MEMORY to one of the above _MEM_ defines.
 #include <Arduino.h>
 #endif  // Blackpill
 
-// ------------- Adafruit Feather M4 Express ------------------
-#if defined(__FEATHER_M4__)
+// ------------- SAMD51 Variants ------------------
+//    - Adafruit Feather M4 Express
+//    - Adafruit Grand Central M4 Express
+//    - Adafruit Metro M4 Express
+//    - ...
+#if defined(__SAMD51__) || defined(__FEATHER_M4__)
 #if defined(KNOWN_PLATFORM)
 #error "Platform already defined"
 #endif
@@ -211,7 +215,7 @@ A Platform sets USTD_FEATURE_MEMORY to one of the above _MEM_ defines.
 #define USTD_FEATURE_MEMORY 192000
 #define __ARM__ 1
 #include <Arduino.h>
-#endif  // FEATHER_M4
+#endif  // SAMD51 || FEATHER_M4
 
 // ------------- Arduino BLE Sense (NRF52840) -----------------
 #if defined(__NANOBLE__)


### PR DESCRIPTION
- Support all SAMD51 based Arm Cortex M4 devices
- Deprecate `__FEATHER_M4__` in favor of `__SAMD51__`
- Warn users about the deprecation
